### PR TITLE
build(deps): bump ruff from 0.15.9 to 0.15.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ colorlog==6.9.0
 # run this command to install the requirements : ./scripts/setup
 homeassistant==2026.4.0
 pip>=26.1
-ruff==0.15.9
+ruff==0.15.12


### PR DESCRIPTION
## Summary\n- replace the stale/conflicted Dependabot ruff bump with a fresh branch on top of current main\n- update `requirements.txt` from `ruff==0.15.9` to `ruff==0.15.12`\n\n## Why\nDependabot PR #138 was no longer mergeable after newer dependency changes landed on `main`. This PR reapplies the same low-risk version bump on top of the latest main so CI can validate it cleanly.