### PR TITLE
fix(AggregatePopup): show entities in global popups when no floor is configured

### DIFF
--- a/src/popups/AggregatePopup.ts
+++ b/src/popups/AggregatePopup.ts
@@ -775,9 +775,15 @@ class AggregatePopup extends AbstractPopup {
       ? [Helper.floors[targetFloorId]].filter(Boolean)
       : Helper.orderedFloors;
 
-    // For global scope: exclude UNDISCLOSED floor entirely (keep popups clean)
+    // For global scope: exclude UNDISCLOSED floor to keep popups clean, but only
+    // when a real floor also exists. Homes without any floor configured in HA
+    // only have UNDISCLOSED — filtering it out unconditionally left those popups
+    // empty even though their areas/entities exist.
     if (scope === "global") {
-      floors = floors.filter(f => f.floor_id !== UNDISCLOSED);
+      const hasRealFloors = floors.some(f => f.floor_id !== UNDISCLOSED);
+      if (hasRealFloors) {
+        floors = floors.filter(f => f.floor_id !== UNDISCLOSED);
+      }
     }
 
     // Helper to process a single floor
@@ -850,13 +856,12 @@ class AggregatePopup extends AbstractPopup {
       }
     };
 
-    // Process regular floors
+    // Process floors. UNDISCLOSED never gets a floor separator, even when kept
+    // above for a floor-less home — there's nothing else to distinguish it from.
     for (const floor of floors) {
-      processFloor(floor, scope === "global");
+      const isUndisclosed = floor.floor_id === UNDISCLOSED;
+      processFloor(floor, scope === "global" && !isUndisclosed);
     }
-
-    // UNDISCLOSED floor is intentionally skipped for global scope to keep popups clean
-    // UNDISCLOSED entities are filtered out at the entity retrieval level
 
     return cards;
   }


### PR DESCRIPTION
## Summary
- Fixes a regression from d6c0e647 (Feb 16): global-scope aggregate popups (the "global" chips on the Home view) showed **zero entities** for any Home Assistant install without a floor configured.

## Root cause
Every area without a real `floor_id` is bucketed under a synthetic `UNDISCLOSED` floor (`Helper.ts`). d6c0e647 unconditionally filtered `UNDISCLOSED` out of the floor list for global-scope popups to avoid mixing a "Non classé" group with real floors. For a home with **no floors at all**, `UNDISCLOSED` is the *only* entry in that list — filtering it out left nothing to iterate, so the popup rendered empty even though the areas/entities exist.

## Fix
Only exclude `UNDISCLOSED` when at least one real floor is also present (restores the original clean-UX intent). When `UNDISCLOSED` is the only floor, it's processed like before d6c0e647 — without a floor separator, since there's nothing else to distinguish it from.

## Test plan
- [x] Traced the regression via `git blame`/`git show` on `src/popups/AggregatePopup.ts` and `src/Helper.ts` to confirm root cause and rule out other regressions in the same commit
- [ ] Manual verification on a HA instance with zero floors configured: global chip popup should list all matching entities grouped by area
- [ ] Manual verification on a HA instance with floors configured: behavior unchanged (UNDISCLOSED still excluded when mixed with real floors)
- [ ] `npm run build` / `type-check` / `lint:check` — not runnable in the environment this PR was authored from (no Node.js available); relying on CI

## Related
Found while reviewing #152 (unrelated) — a user reported the home dashboard's global chip popups were empty on an install without floors.